### PR TITLE
feat: add support for group expressions on path nodes

### DIFF
--- a/src/plugin/__tests__/index.unit.ts
+++ b/src/plugin/__tests__/index.unit.ts
@@ -44,6 +44,8 @@ describe("prettierPlugin", () => {
     ["-foo"],
     ["foo = 1"],
     ["foo.bar"],
+    ["foo.bar{}"],
+    ["foo.bar{ baz: boo }"],
     ["foo[bar = 1]"],
     ["foo[0]"],
     ["$"],

--- a/src/plugin/printer.ts
+++ b/src/plugin/printer.ts
@@ -179,10 +179,8 @@ const printPathNodeGroup: PrintNodeFunction<PathNode> = (node, path, options, pr
     group([printChildren(["group", "lhs", idx, 0]), ": ", printChildren(["group", "lhs", idx, 1])]),
   );
 
-  const hasNestedObjectChildren = node.group.lhs.some(
-    (tuple) => tuple[1].type === "unary" && ["[", "{"].includes(tuple[1].value),
-  );
-  const linebreak = hasNestedObjectChildren ? [hardline, breakParent] : line;
+  const hasNestedComplexUnaryNodeChildren = node.group.lhs.some((tuple) => isComplexUnaryNode(tuple[1]));
+  const linebreak = hasNestedComplexUnaryNodeChildren ? [hardline, breakParent] : line;
 
   const joinedUnaryTuples = join([",", linebreak], unaryTuples);
   return group(["{", indent([linebreak, joinedUnaryTuples]), linebreak, "}"]);
@@ -367,13 +365,31 @@ const printUnaryTuplesForObjectUnaryNode: PrintNodeFunction<ObjectUnaryNode> = (
     group([printChildren(["lhs", idx, 0]), ": ", printChildren(["lhs", idx, 1])]),
   );
 
-  const hasNestedObjectChildren = node.lhs.some(
-    (tuple) => tuple[1].type === "unary" && ["[", "{"].includes(tuple[1].value),
-  );
-  const linebreak = hasNestedObjectChildren ? [hardline, breakParent] : line;
+  const hasNestedComplexUnaryNodeChildren = node.lhs.some((tuple) => isComplexUnaryNode(tuple[1]));
+  const linebreak = hasNestedComplexUnaryNodeChildren ? [hardline, breakParent] : line;
 
   const joinedUnaryTuples = join([",", linebreak], unaryTuples);
   return [indent([linebreak, joinedUnaryTuples]), linebreak];
+};
+
+/**
+ * Returns true, if the provided `node` argument represents an Unary Node
+ * which could be considered complex ("negation" node is not considered context).
+ *
+ * This function can be used to decide which line break type to use based on AST tree complexity.
+ */
+const isComplexUnaryNode = (node: JsonataASTNode) => {
+  if (node.type !== "unary") {
+    return false;
+  }
+
+  if (node.value === "[") {
+    return true;
+  }
+
+  if (node.value === "{") {
+    return true;
+  }
 };
 
 const printArrayUnaryNode: PrintNodeFunction<ArrayUnaryNode> = (node, path, options, printChildren) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,9 @@ export interface PathNode extends Node {
   type: "path";
   steps: JsonataASTNode[];
   keepSingletonArray?: boolean;
+  group?: {
+    lhs: UnaryTuple[];
+  };
 }
 
 export interface BlockNode extends Node {


### PR DESCRIPTION
This PR adds support for serializing `group` expressions on the `PathNode`.

Examples of such expressions:
```
foo{}
foo.bar{}
foo.bar{ baz: boo }
foo.bar{ baz: boo, bee: baa }
```