### PR TITLE
fix: support JSONata grouping feature on the majority of node types

### DIFF
--- a/src/plugin/__tests__/index.unit.ts
+++ b/src/plugin/__tests__/index.unit.ts
@@ -52,6 +52,8 @@ describe("prettierPlugin", () => {
     ["$.foo"],
     ["$$"],
     ["$$.foo"],
+    ["${ k: v }"],
+    ["$${ k: v }"],
     ["$foo"],
     ["-$foo"],
     ["$foo()"],
@@ -570,6 +572,53 @@ describe("prettierPlugin", () => {
 
     formatted = format(`foo.{ "foo": bar.{ "bar": %.%@$j#$i } }`);
     expect(formatted).toMatchInlineSnapshot(`"foo.{ \\"foo\\": bar.{ \\"bar\\": %.%@$j#$i } }"`);
+  });
+
+  test("handles grouping on the majority of node types", () => {
+    let formatted = format(`foo{ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"foo{ k: v }"`);
+
+    formatted = format(`foo.bar{ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"foo.bar{ k: v }"`);
+
+    formatted = format(`$foo{ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"$foo{ k: v }"`);
+
+    formatted = format(`"foo"{ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"\\"foo\\"{ k: v }"`);
+
+    formatted = format(`123{ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"123{ k: v }"`);
+
+    formatted = format(`true{ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"true{ k: v }"`);
+
+    formatted = format(`null{ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"null{ k: v }"`);
+
+    formatted = format(`foo(bar){ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"foo(bar){ k: v }"`);
+
+    formatted = format(`{ "foo": bar }{ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"{ \\"foo\\": bar }{ k: v }"`);
+
+    formatted = format(`[foo, bar]{ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"[foo, bar]{ k: v }"`);
+
+    formatted = format(`(foo){ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"(foo){ k: v }"`);
+
+    formatted = format(`foo(){ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"foo(){ k: v }"`);
+
+    formatted = format(`function() { foo }{ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"function() { foo }{ k: v }"`);
+
+    formatted = format(`foo.{ "foo": %{ k: v } }`);
+    expect(formatted).toMatchInlineSnapshot(`"foo.{ \\"foo\\": %{ k: v } }"`);
+
+    formatted = format(`foo.{ "foo": bar.{ "bar": %.%{ k: v } } }`);
+    expect(formatted).toMatchInlineSnapshot(`"foo.{ \\"foo\\": bar.{ \\"bar\\": %.%{ k: v } } }"`);
   });
 
   test.each([

--- a/src/plugin/printer.ts
+++ b/src/plugin/printer.ts
@@ -103,6 +103,7 @@ const printBinaryNode: PrintNodeFunction<BinaryNode> = (node, path, options, pri
 const printNameNode: PrintNodeFunction<NameNode> = (node, path, options, printChildren) => {
   return group([
     printEscapedNameNodeValue(node.value),
+    printNodeGroup(node, path, options, printChildren),
     printNodeFocus(node),
     printNodeIndex(node),
     printStages(node, path, options, printChildren),
@@ -127,6 +128,7 @@ const printEscapedNameNodeValue = (name: string) => {
 const printNumberNode: PrintNodeFunction<NumberNode> = (node, path, options, printChildren) => {
   return group([
     JSON.stringify(node.value),
+    printNodeGroup(node, path, options, printChildren),
     printNodeFocus(node),
     printNodeIndex(node),
     printPredicate(node, path, options, printChildren),
@@ -137,6 +139,7 @@ const printNumberNode: PrintNodeFunction<NumberNode> = (node, path, options, pri
 const printStringNode: PrintNodeFunction<StringNode> = (node, path, options, printChildren) => {
   return group([
     JSON.stringify(node.value),
+    printNodeGroup(node, path, options, printChildren),
     printNodeFocus(node),
     printNodeIndex(node),
     printPredicate(node, path, options, printChildren),
@@ -157,29 +160,7 @@ const printPathNode: PrintNodeFunction<PathNode> = (node, path, options, printCh
     return indent([softline, ".", printChildren(["steps", idx])]);
   });
 
-  const pathGroup = node.group ? printPathNodeGroup(node, path, options, printChildren) : "";
-
-  return group([...steps, pathGroup]);
-};
-
-const printPathNodeGroup: PrintNodeFunction<PathNode> = (node, path, options, printChildren) => {
-  if (node.group === undefined) {
-    return "";
-  }
-
-  if (node.group.lhs.length === 0) {
-    return "{}";
-  }
-
-  const unaryTuples = node.group.lhs.map((tuple, idx) =>
-    group([printChildren(["group", "lhs", idx, 0]), ": ", printChildren(["group", "lhs", idx, 1])]),
-  );
-
-  const hasNestedComplexUnaryNodeChildren = node.group.lhs.some((tuple) => isComplexUnaryNode(tuple[1]));
-  const linebreak = hasNestedComplexUnaryNodeChildren ? [hardline, breakParent] : line;
-
-  const joinedUnaryTuples = join([",", linebreak], unaryTuples);
-  return group(["{", indent([linebreak, joinedUnaryTuples]), linebreak, "}"]);
+  return group([...steps, printNodeGroup(node, path, options, printChildren)]);
 };
 
 type PrintFunctionNodeFunction = PrintNodeFunction<FunctionNode | PartialFunctionNode>;
@@ -189,6 +170,7 @@ const printFunctionNode: PrintFunctionNodeFunction = (node, path, options, print
     "(",
     printFunctionArguments(node, path, options, printChildren),
     ")",
+    printNodeGroup(node, path, options, printChildren),
     printNodeFocus(node),
     printNodeIndex(node),
     printPredicate(node, path, options, printChildren),
@@ -214,6 +196,7 @@ const printVariableNode: PrintNodeFunction<VariableNode> = (node, path, options,
   return group([
     "$",
     node.value,
+    printNodeGroup(node, path, options, printChildren),
     printNodeFocus(node),
     printNodeIndex(node),
     printPredicate(node, path, options, printChildren),
@@ -254,6 +237,7 @@ const printLambdaNode: PrintNodeFunction<LambdaNode> = (node, path, options, pri
     indent([line, printChildren("body")]),
     line,
     "}",
+    printNodeGroup(node, path, options, printChildren),
     printNodeFocus(node),
     printNodeIndex(node),
     printPredicate(node, path, options, printChildren),
@@ -276,6 +260,7 @@ const printConditionNode: PrintNodeFunction<ConditionNode> = (node, path, option
 const printValueNode: PrintNodeFunction<ValueNode> = (node, path, options, printChildren) => {
   return group([
     printValueNodeValue(node, path, options, printChildren),
+    printNodeGroup(node, path, options, printChildren),
     printNodeFocus(node),
     printNodeIndex(node),
     printPredicate(node, path, options, printChildren),
@@ -301,6 +286,7 @@ const printBlockNode: PrintNodeFunction<BlockNode> = (node, path, options, print
       "(",
       printChildren(["expressions", 0]),
       ")",
+      printNodeGroup(node, path, options, printChildren),
       printNodeFocus(node),
       printNodeIndex(node),
       printPredicate(node, path, options, printChildren),
@@ -314,6 +300,7 @@ const printBlockNode: PrintNodeFunction<BlockNode> = (node, path, options, print
     indent([hardline, joinedExpressions]),
     hardline,
     ")",
+    printNodeGroup(node, path, options, printChildren),
     printNodeFocus(node),
     printNodeIndex(node),
     printPredicate(node, path, options, printChildren),
@@ -359,6 +346,7 @@ const printObjectUnaryNode: PrintNodeFunction<ObjectUnaryNode> = (node, path, op
     "{",
     printUnaryTuplesForObjectUnaryNode(node, path, options, printChildren),
     "}",
+    printNodeGroup(node, path, options, printChildren),
     printNodeFocus(node),
     printNodeIndex(node),
     printPredicate(node, path, options, printChildren),
@@ -410,6 +398,7 @@ const printArrayUnaryNode: PrintNodeFunction<ArrayUnaryNode> = (node, path, opti
     indent([softline, joinedExpressions]),
     softline,
     "]",
+    printNodeGroup(node, path, options, printChildren),
     printNodeFocus(node),
     printNodeIndex(node),
     printPredicate(node, path, options, printChildren),
@@ -424,6 +413,7 @@ const printNegationUnaryNode: PrintNodeFunction<NegationUnaryNode> = (node, path
 const printParentNode: PrintNodeFunction<ParentNode> = (node, path, options, printChildren) => {
   return group([
     "%",
+    printNodeGroup(node, path, options, printChildren),
     printNodeFocus(node),
     printNodeIndex(node),
     printPredicate(node, path, options, printChildren),
@@ -469,4 +459,24 @@ const printKeepArray = (node: JsonataASTNode) => {
     return "";
   }
   return "[]";
+};
+
+const printNodeGroup: PrintNodeFunction = (node, path, options, printChildren) => {
+  if (node.group === undefined) {
+    return "";
+  }
+
+  if (node.group.lhs.length === 0) {
+    return "{}";
+  }
+
+  const unaryTuples = node.group.lhs.map((tuple, idx) =>
+    group([printChildren(["group", "lhs", idx, 0]), ": ", printChildren(["group", "lhs", idx, 1])]),
+  );
+
+  const hasNestedComplexUnaryNodeChildren = node.group.lhs.some((tuple) => isComplexUnaryNode(tuple[1]));
+  const linebreak = hasNestedComplexUnaryNodeChildren ? [hardline, breakParent] : line;
+
+  const joinedUnaryTuples = join([",", linebreak], unaryTuples);
+  return group(["{", indent([linebreak, joinedUnaryTuples]), linebreak, "}"]);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,9 @@ export interface Node {
   focus?: string;
   index?: string;
   tuple?: true;
+  group?: {
+    lhs: UnaryTuple[];
+  };
 }
 
 export interface NumberNode extends Node {
@@ -63,9 +66,6 @@ export interface PathNode extends Node {
   type: "path";
   steps: JsonataASTNode[];
   keepSingletonArray?: boolean;
-  group?: {
-    lhs: UnaryTuple[];
-  };
 }
 
 export interface BlockNode extends Node {


### PR DESCRIPTION
It turns out that the [JSONata grouping feature](https://docs.jsonata.org/sorting-grouping#grouping) is available not only on the `PathNode`but on the majority of other node types too (similar to [JSONata path operators](https://docs.jsonata.org/path-operators)) - this PR extends support for it.