### PR TITLE
fix: support filters on code blocks within a path

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -11,4 +11,4 @@ jobs:
           github.actor == 'dependabot-preview' ||
           github.actor == 'mergify[bot]'
         with:
-          github-token: ${{ secrets.PACKAGE_GITHUB_TOKEN }}
+          github-token: ${{ secrets.PUBLIC_PACKAGE_GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,10 +21,10 @@ jobs:
           max_attempts: 3
           command: npm ci
         env:
-          GITHUB_TOKEN: ${{secrets.PACKAGE_GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}
       - run: npm run build
         env:
-          GITHUB_TOKEN: ${{secrets.PACKAGE_GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}
       - uses: crazy-max/ghaction-import-gpg@v3
         with:
           gpg-private-key: ${{secrets.STEDI_ENGINEERING_PUBLIC_REPO_GPG_PRIVATE_KEY}}
@@ -34,4 +34,4 @@ jobs:
         id: import_gpg
       - run: npm run check
         env:
-          GITHUB_TOKEN: ${{secrets.PACKAGE_GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: 14
       - run: npm ci
         env:
-          GITHUB_TOKEN: ${{secrets.PACKAGE_GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}
       - run: npm run build
       - run: npm run check
       - uses: crazy-max/ghaction-import-gpg@v3
@@ -35,7 +35,7 @@ jobs:
           GIT_COMMITTER_NAME: ${{steps.import_gpg.outputs.name}}
           GIT_AUTHOR_EMAIL: ${{steps.import_gpg.outputs.email}}
           GIT_COMMITTER_EMAIL: ${{steps.import_gpg.outputs.email}}
-          GITHUB_TOKEN: ${{secrets.PACKAGE_GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm cache clear --force
 
@@ -53,7 +53,7 @@ jobs:
       - run: 'echo "released_version: ${{needs.release-external.outputs.released_version}}"'
       - run: npm ci
         env:
-          GITHUB_TOKEN: ${{secrets.PACKAGE_GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}
       - run: npm run build
       - run: npm run check
       - uses: crazy-max/ghaction-import-gpg@v3
@@ -69,10 +69,10 @@ jobs:
           GIT_COMMITTER_NAME: ${{steps.import_gpg.outputs.name}}
           GIT_AUTHOR_EMAIL: ${{steps.import_gpg.outputs.email}}
           GIT_COMMITTER_EMAIL: ${{steps.import_gpg.outputs.email}}
-          GITHUB_TOKEN: ${{secrets.PACKAGE_GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: sed -i 's/registry.npmjs.org/npm.pkg.github.com\/Stedi/' package.json
       - run: sed -i '/"access":\ "public"/d' package.json
       - run: npm publish
         env:
-          GITHUB_TOKEN: ${{secrets.PACKAGE_GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}

--- a/src/plugin/__tests__/index.unit.ts
+++ b/src/plugin/__tests__/index.unit.ts
@@ -461,6 +461,9 @@ describe("prettierPlugin", () => {
     formatted = format(`(foo)[0]`);
     expect(formatted).toMatchInlineSnapshot(`"(foo)[0]"`);
 
+    formatted = format(`foo.(bar)[0]`);
+    expect(formatted).toMatchInlineSnapshot(`"foo.(bar)[0]"`);
+
     formatted = format(`foo()[0]`);
     expect(formatted).toMatchInlineSnapshot(`"foo()[0]"`);
 
@@ -510,6 +513,9 @@ describe("prettierPlugin", () => {
 
     formatted = format(`(foo)[]`);
     expect(formatted).toMatchInlineSnapshot(`"(foo)[]"`);
+
+    formatted = format(`foo.(bar)[]`);
+    expect(formatted).toMatchInlineSnapshot(`"foo.(bar)[]"`);
 
     formatted = format(`foo()[]`);
     expect(formatted).toMatchInlineSnapshot(`"foo()[]"`);
@@ -607,6 +613,9 @@ describe("prettierPlugin", () => {
 
     formatted = format(`(foo){ k: v }`);
     expect(formatted).toMatchInlineSnapshot(`"(foo){ k: v }"`);
+
+    formatted = format(`foo.(bar){ k: v }`);
+    expect(formatted).toMatchInlineSnapshot(`"foo.(bar){ k: v }"`);
 
     formatted = format(`foo(){ k: v }`);
     expect(formatted).toMatchInlineSnapshot(`"foo(){ k: v }"`);

--- a/src/plugin/printer.ts
+++ b/src/plugin/printer.ts
@@ -325,6 +325,7 @@ const printBlockNode: PrintNodeFunction<BlockNode> = (node, path, options, print
       printNodeIndex(node),
       printPredicate(node, path, options, printChildren),
       printKeepArray(node),
+      printStages(node, path, options, printChildren),
     ]);
   }
 
@@ -480,7 +481,12 @@ const printPredicate: PrintNodeFunction = (node, path, options, printChildren) =
   return path.map(printChildren, "predicate");
 };
 
-const printStages: PrintNodeFunction<NameNode | VariableNode | ParentNode> = (node, path, options, printChildren) => {
+const printStages: PrintNodeFunction<NameNode | VariableNode | ParentNode | BlockNode> = (
+  node,
+  path,
+  options,
+  printChildren,
+) => {
   if (!node.stages) {
     return "";
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export interface PathNode extends Node {
 export interface BlockNode extends Node {
   type: "block";
   expressions: JsonataASTNode[];
+  stages?: JsonataASTNode[];
 }
 
 export interface ApplyNode extends Node {


### PR DESCRIPTION
Example expression which will now be supported: `foo.(bar)[a="b"]`.

The interesting part is that both `foo.bar[a="b"]` and `(bar)[a="b"]` were working just fine even before this change, but it turned out that JSONata puts the filter expression into a different prop in these cases.