### PR TITLE
feat: support formatting of regex node

### DIFF
--- a/src/plugin/__tests__/index.unit.ts
+++ b/src/plugin/__tests__/index.unit.ts
@@ -118,6 +118,10 @@ describe("prettierPlugin", () => {
     ['$split("1,2,3", ",")[1]'],
     ['["foo", "bar"][0]'],
     ["$number(number_of_units_shipped_05)"],
+    ["/(\\w+)\\s(\\w+)/"],
+    ["/(\\w+)\\s(\\w+)/i"],
+    ["/(\\w+)\\s(\\w+)/m"],
+    ["/(\\w+)\\s(\\w+)/im"],
   ])("can format simple %p example without changes", (input) => {
     const formatted = format(input);
     expect(formatted).toEqual(input);

--- a/src/plugin/__tests__/index.unit.ts
+++ b/src/plugin/__tests__/index.unit.ts
@@ -118,9 +118,9 @@ describe("prettierPlugin", () => {
     ['$split("1,2,3", ",")[1]'],
     ['["foo", "bar"][0]'],
     ["$number(number_of_units_shipped_05)"],
-    ["/(\\w+)\\s(\\w+)/"],
-    ["/(\\w+)\\s(\\w+)/i"],
-    ["/(\\w+)\\s(\\w+)/m"],
+    ["/g(oog)+le/"],
+    ["/\\d{5}(-\\d{4})?/i"],
+    ["/[2-9]|[12]\\d|3[0-6]/m"],
     ["/(\\w+)\\s(\\w+)/im"],
   ])("can format simple %p example without changes", (input) => {
     const formatted = format(input);

--- a/src/plugin/printer.ts
+++ b/src/plugin/printer.ts
@@ -24,6 +24,7 @@ import type {
   WildcardNode,
   OperatorNode,
   NegationUnaryNode,
+  RegexNode,
 } from "../types";
 import * as prettier from "prettier";
 import type { AstPath, Doc, Options, Printer } from "prettier";
@@ -108,6 +109,8 @@ const printNode: PrintNodeFunction = (node, ...commonPrintArgs) => {
     return printUnaryNode(node, ...commonPrintArgs);
   } else if (node.type === "parent") {
     return printParentNode(node, ...commonPrintArgs);
+  } else if (node.type === "regex") {
+    return printRegEx(node, ...commonPrintArgs);
   }
 
   throw new Error(`Unknown node type: ${(node as JsonataASTNode).type}`);
@@ -441,6 +444,22 @@ const printParentNode: PrintNodeFunction<ParentNode> = (node, path, options, pri
     printPredicate(node, path, options, printChildren),
     printKeepArray(node),
     printStages(node, path, options, printChildren),
+  ]);
+};
+
+// https://github.com/jsonata-js/jsonata/blob/master/src/parser.js#L95
+const supportedRegexFlags = ["i", "m"];
+
+const printRegEx: PrintNodeFunction<RegexNode> = (node, path, options, printChildren) => {
+  const flags = supportedRegexFlags.filter((flag) => node.value.flags.includes(flag)).join("");
+
+  return group([
+    `/${node.value.source}/${flags}`,
+    printNodeGroup(node, path, options, printChildren),
+    printNodeFocus(node),
+    printNodeIndex(node),
+    printPredicate(node, path, options, printChildren),
+    printKeepArray(node),
   ]);
 };
 

--- a/src/plugin/printer.ts
+++ b/src/plugin/printer.ts
@@ -447,7 +447,7 @@ const printParentNode: PrintNodeFunction<ParentNode> = (node, path, options, pri
   ]);
 };
 
-// https://github.com/jsonata-js/jsonata/blob/master/src/parser.js#L95
+// https://github.com/jsonata-js/jsonata/blob/3cea53fe5f2bc94d9026fafb109a1c148fc7679b/src/parser.js#L95
 const supportedRegexFlags = ["i", "m"];
 
 const printRegEx: PrintNodeFunction<RegexNode> = (node, path, options, printChildren) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,6 +163,11 @@ export interface ParentNode extends Node {
   stages?: JsonataASTNode[];
 }
 
+export interface RegexNode extends Node {
+  type: "regex";
+  value: RegExp;
+}
+
 export type LiteralNode = NumberNode | StringNode | ValueNode;
 
 export type JsonataASTNode =
@@ -186,4 +191,5 @@ export type JsonataASTNode =
   | BindNode
   | LambdaNode
   | SortNode
-  | ParentNode;
+  | ParentNode
+  | RegexNode;


### PR DESCRIPTION
"regex" node type of JSONata AST was not known to the prettier plugin, this PR is adding support for it.