### PR TITLE
fix: bump minimist from 1.2.5 to 1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4920,9 +4920,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minimist-options": {


### PR DESCRIPTION
![Screenshot 2022-08-08 at 11 00 21](https://user-images.githubusercontent.com/16646517/183380834-e8ecbf32-1e1b-4f8e-9269-e71032d20acd.png)
