### PR TITLE
feat: add GH token setup job to GHA

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,10 +6,27 @@ on:
       - synchronize
       - reopened
 jobs:
+  github-token-setup-job:
+    runs-on: ubuntu-latest
+    outputs:
+      github_token: ${{ steps.set-variable.outputs.github_token }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set test variable
+        id: set-variable
+        run: |
+          if [ "${{ secrets.PUBLIC_PACKAGE_GITHUB_TOKEN }}" != "" ]; then
+            echo "::set-output name=github_token::${{ secrets.PUBLIC_PACKAGE_GITHUB_TOKEN }}"
+          elif [ "${{ secrets.PUBLIC_DEPENDABOT_PACKAGE_TOKEN }}" != "" ]; then
+            echo "::set-output name=github_token::${{ secrets.PUBLIC_DEPENDABOT_PACKAGE_TOKEN }}"
+          fi
+        shell: bash
+
   check:
     runs-on: ubuntu-latest
+    needs: [github-token-setup-job]
     env:
-      GITHUB_TOKEN: placeholder
+      GITHUB_TOKEN: ${{needs.github-token-setup-job.outputs.github_token}}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -20,11 +37,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           command: npm ci
-        env:
-          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}
       - run: npm run build
-        env:
-          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}
       - uses: crazy-max/ghaction-import-gpg@v3
         with:
           gpg-private-key: ${{secrets.STEDI_ENGINEERING_PUBLIC_REPO_GPG_PRIVATE_KEY}}
@@ -33,5 +46,3 @@ jobs:
           git-commit-gpgsign: true
         id: import_gpg
       - run: npm run check
-        env:
-          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
       - synchronize
       - reopened
 jobs:
+  # Our GH actions are expected to be executed by the dependabot in addition to regular executions by Pull Request creators, 
+  # and the `GITHUB_TOKEN` env var has a different name in dependabot's secrets (PUBLIC_DEPENDABOT_PACKAGE_TOKEN vs PUBLIC_PACKAGE_GITHUB_TOKEN).
+  # To workaround that, we are adding this additional setup job, which outputs the one secret that is present for the current action execution.
   github-token-setup-job:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,20 +4,35 @@ on:
     branches:
       - main
 jobs:
+  github-token-setup-job:
+    runs-on: ubuntu-latest
+    outputs:
+      github_token: ${{ steps.set-variable.outputs.github_token }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set test variable
+        id: set-variable
+        run: |
+          if [ "${{ secrets.PUBLIC_PACKAGE_GITHUB_TOKEN }}" != "" ]; then
+            echo "::set-output name=github_token::${{ secrets.PUBLIC_PACKAGE_GITHUB_TOKEN }}"
+          elif [ "${{ secrets.PUBLIC_DEPENDABOT_PACKAGE_TOKEN }}" != "" ]; then
+            echo "::set-output name=github_token::${{ secrets.PUBLIC_DEPENDABOT_PACKAGE_TOKEN }}"
+          fi
+        shell: bash
+
   release-external:
     runs-on: ubuntu-latest
+    needs: [github-token-setup-job]
     outputs:
       released_version: ${{ steps.release.outputs.released_version }}
     env:
-      GITHUB_TOKEN: placeholder
+      GITHUB_TOKEN: ${{needs.github-token-setup-job.outputs.github_token}}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: 14
-      - run: npm ci
-        env:
-          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}
+      - run: npm ci        
       - run: npm run build
       - run: npm run check
       - uses: crazy-max/ghaction-import-gpg@v3
@@ -35,16 +50,15 @@ jobs:
           GIT_COMMITTER_NAME: ${{steps.import_gpg.outputs.name}}
           GIT_AUTHOR_EMAIL: ${{steps.import_gpg.outputs.email}}
           GIT_COMMITTER_EMAIL: ${{steps.import_gpg.outputs.email}}
-          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm cache clear --force
 
   release-internal:
-    needs: release-external
+    needs: [release-external, github-token-setup-job]
     if: needs.release-external.outputs.released_version != ''
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: placeholder
+      GITHUB_TOKEN: ${{needs.github-token-setup-job.outputs.github_token}}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -52,8 +66,6 @@ jobs:
           node-version: 14
       - run: 'echo "released_version: ${{needs.release-external.outputs.released_version}}"'
       - run: npm ci
-        env:
-          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}
       - run: npm run build
       - run: npm run check
       - uses: crazy-max/ghaction-import-gpg@v3
@@ -69,10 +81,7 @@ jobs:
           GIT_COMMITTER_NAME: ${{steps.import_gpg.outputs.name}}
           GIT_AUTHOR_EMAIL: ${{steps.import_gpg.outputs.email}}
           GIT_COMMITTER_EMAIL: ${{steps.import_gpg.outputs.email}}
-          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: sed -i 's/registry.npmjs.org/npm.pkg.github.com\/Stedi/' package.json
       - run: sed -i '/"access":\ "public"/d' package.json
       - run: npm publish
-        env:
-          GITHUB_TOKEN: ${{secrets.PUBLIC_PACKAGE_GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 jobs:
+  # Our GH actions are expected to be executed by the dependabot in addition to regular executions by Pull Request creators, 
+  # and the `GITHUB_TOKEN` env var has a different name in dependabot's secrets (PUBLIC_DEPENDABOT_PACKAGE_TOKEN vs PUBLIC_PACKAGE_GITHUB_TOKEN).
+  # To workaround that, we are adding this additional setup job, which outputs the one secret that is present for the current action execution.
   github-token-setup-job:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Our GH actions are now expected to be run by the dependabot as well, and the `GITHUB_TOKEN` env var has a different name in dependabot's secrets (`PUBLIC_DEPENDABOT_PACKAGE_TOKEN` vs `PUBLIC_PACKAGE_GITHUB_TOKEN`).

To workaround that, we are adding additional setup job to our GH actions which require that variable.