### PR TITLE
chore: amend renovate config + check the PR author to trigger the notification

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,6 +37,8 @@ jobs:
     needs: [check]
     steps:
       - name: Notify about the dependency update
+        if: |
+          contains(fromJson('["renovate[bot]", "dependabot[bot]"]'), github.actor)
         run: |
           curl "${{ secrets.SLACK_ALERTS_CHANNEL_WEBHOOK_URL }}" \
           --data-raw '{"blocks":[{"type":"header","text":{"type":"plain_text","text":"Automated dependency upgrade in PRETTIER-PLUGIN-JSONATA needs a review","emoji":true}},{"type":"section","text":{"type":"mrkdwn","text":"<https://github.com/Stedi/prettier-plugin-jsonata/pull/${{ github.event.pull_request.number }}|Link to the PR>"}}]}' \

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,40 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>Stedi/renovate-config"],
+  "extends": ["config:base"],
+  "stabilityDays": 21,
+  "internalChecksFilter": "strict",
+  "dependencyDashboard": true,
+  "major": {
+    "automerge": false,
+    "dependencyDashboardApproval": true,
+    "addLabels": ["major-upgrade"]
+  },
+  "replacement": {
+    "automerge": false,
+    "addLabels": ["replacement"]
+  },
+  "vulnerabilityAlerts": {
+    "addLabels": ["security"]
+  },
+  "packageRules": [
+    {
+      "matchSourceUrlPrefixes": ["https://github.com/aws", "https://github.com/microsoft"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest", "lockFileMaintenance", "rollback", "bump"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true,
+      "platformAutomerge": true,
+      "stabilityDays": 3,
+      "addLabels": ["dependencies"]
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest", "lockFileMaintenance", "rollback", "bump"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true,
+      "platformAutomerge": true,
+      "addLabels": ["dependencies"]
+    }
+  ],
+  "npmrcMerge": true,
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["at any time"],


### PR DESCRIPTION
Added a manual renovate config, since the one we use only makes sense for private packages.