### PR TITLE
chore: notify about renovate PRs only once

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,17 +29,3 @@ jobs:
           git-commit-gpgsign: true
         id: import_gpg
       - run: npm run check
-
-  notify-on-dependency-update:
-    runs-on: ubuntu-latest
-    # Always run the action, even if the jobs defined in the `needs` array failed.
-    if: ${{ always() }}
-    needs: [check]
-    steps:
-      - name: Notify about the dependency update
-        if: |
-          contains(fromJson('["renovate[bot]", "dependabot[bot]"]'), github.actor)
-        run: |
-          curl "${{ secrets.SLACK_ALERTS_CHANNEL_WEBHOOK_URL }}" \
-          --data-raw '{"blocks":[{"type":"header","text":{"type":"plain_text","text":"Automated dependency upgrade in PRETTIER-PLUGIN-JSONATA needs a review","emoji":true}},{"type":"section","text":{"type":"mrkdwn","text":"<https://github.com/Stedi/prettier-plugin-jsonata/pull/${{ github.event.pull_request.number }}|Link to the PR>"}}]}' \
-          --compressed

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,20 @@
+name: check
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+jobs:
+  notify-on-dependency-update:
+    runs-on: ubuntu-latest
+    # Always run the action, even if the jobs defined in the `needs` array failed.
+    if: ${{ always() }}
+    needs: [check]
+    steps:
+      - name: Notify about the dependency update
+        if: |
+          contains(fromJson('["renovate[bot]", "dependabot[bot]"]'), github.actor)
+        run: |
+          curl "${{ secrets.SLACK_ALERTS_CHANNEL_WEBHOOK_URL }}" \
+          --data-raw '{"blocks":[{"type":"header","text":{"type":"plain_text","text":"Automated dependency upgrade in PRETTIER-PLUGIN-JSONATA needs a review","emoji":true}},{"type":"section","text":{"type":"mrkdwn","text":"<https://github.com/Stedi/prettier-plugin-jsonata/pull/${{ github.event.pull_request.number }}|Link to the PR>"}}]}' \
+          --compressed


### PR DESCRIPTION
To avoid repetitive notifications in Slack about the same PR as it's being rebased by the renovate bot, I'm changing the notify workflow to only run on PR states "opened" and "reopened" but not "synchronized".