### PR TITLE
chore: update webhook URL

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -12,6 +12,6 @@ jobs:
         if: |
           contains(fromJson('["renovate[bot]", "dependabot[bot]"]'), github.actor)
         run: |
-          curl "${{ secrets.SLACK_ALERTS_CHANNEL_WEBHOOK_URL }}" \
+          curl "${{ secrets.SLACK_DEPS_CHANNEL_WEBHOOK_URL }}" \
           --data-raw '{"blocks":[{"type":"header","text":{"type":"plain_text","text":"Automated dependency upgrade in PRETTIER-PLUGIN-JSONATA needs a review","emoji":true}},{"type":"section","text":{"type":"mrkdwn","text":"<https://github.com/Stedi/prettier-plugin-jsonata/pull/${{ github.event.pull_request.number }}|Link to the PR>"}}]}' \
           --compressed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1205,18 +1205,18 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.1.0.tgz",
-      "integrity": "sha512-Z7vzLqfTkoVQyoy/2iQla1N2I4Vav2wi4JbZK8QxIYAfBimhuflosFxmsqw5LTH7DkdNW46ZYpAcqJf0XaS8SQ==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.4.0.tgz",
+      "integrity": "sha512-2mVzW0X1+HDO3jF80/+QFZNzJiTefELKbhMu6yaBYbp/1gSMkVDm4rT472gJljTokWUlXaaE63m7WrWENhMDLw==",
       "dev": true
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.0.0.tgz",
-      "integrity": "sha512-g4GJMt/7VDmIMMdQenN6bmsmRoZca1c7IxOdF2yMiMwQYrE2bmmypGQeQSD5rsaffsFMCUS7Br4pMVZamareYA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.1.0.tgz",
+      "integrity": "sha512-2O5K5fpajYG5g62wjzHR7/cWYaCA88CextAW3vFP+yoIHD0KEdlVMHfM5/i5LyV+JMmqiYW7w5qfg46FR+McNw==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^7.0.0"
+        "@octokit/types": "^7.1.1"
       }
     },
     "@octokit/plugin-request-log": {
@@ -1273,12 +1273,12 @@
       }
     },
     "@octokit/types": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.1.0.tgz",
-      "integrity": "sha512-+ClA0jRc9zGFj5mfQeQNfgTlelzhpAexbAueQG1t2Xn8yhgnsjkF8bgLcUUpwrpqkv296uXyiGwkqXRSU7KYzQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.1.1.tgz",
+      "integrity": "sha512-Dx6cNTORyVaKY0Yeb9MbHksk79L8GXsihbG6PtWqTpkyA2TY1qBWE26EQXVG3dHwY9Femdd/WEeRUEiD0+H3TQ==",
       "dev": true,
       "requires": {
-        "@octokit/openapi-types": "^13.1.0"
+        "@octokit/openapi-types": "^13.4.0"
       }
     },
     "@semantic-release/commit-analyzer": {
@@ -1466,30 +1466,30 @@
       }
     },
     "@swc/core": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.239.tgz",
-      "integrity": "sha512-U3tbnOBykfLGIJRQ+bSxVsgyTPQ5l9zTe2YQq3GULnxe6rfsgEYN54Uelp9vr3w7LXfW0k+bteXS6YGLpmnEfw==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.241.tgz",
+      "integrity": "sha512-zDUpW3ffFllBi2c5ui9JXl7zUjzMOOZGwy9JCAsodWo7DXWjw5pJF4GsTCzaYHDf62XQzQWuL7zGyRnJyMiyAA==",
       "dev": true,
       "requires": {
-        "@swc/core-android-arm-eabi": "1.2.239",
-        "@swc/core-android-arm64": "1.2.239",
-        "@swc/core-darwin-arm64": "1.2.239",
-        "@swc/core-darwin-x64": "1.2.239",
-        "@swc/core-freebsd-x64": "1.2.239",
-        "@swc/core-linux-arm-gnueabihf": "1.2.239",
-        "@swc/core-linux-arm64-gnu": "1.2.239",
-        "@swc/core-linux-arm64-musl": "1.2.239",
-        "@swc/core-linux-x64-gnu": "1.2.239",
-        "@swc/core-linux-x64-musl": "1.2.239",
-        "@swc/core-win32-arm64-msvc": "1.2.239",
-        "@swc/core-win32-ia32-msvc": "1.2.239",
-        "@swc/core-win32-x64-msvc": "1.2.239"
+        "@swc/core-android-arm-eabi": "1.2.241",
+        "@swc/core-android-arm64": "1.2.241",
+        "@swc/core-darwin-arm64": "1.2.241",
+        "@swc/core-darwin-x64": "1.2.241",
+        "@swc/core-freebsd-x64": "1.2.241",
+        "@swc/core-linux-arm-gnueabihf": "1.2.241",
+        "@swc/core-linux-arm64-gnu": "1.2.241",
+        "@swc/core-linux-arm64-musl": "1.2.241",
+        "@swc/core-linux-x64-gnu": "1.2.241",
+        "@swc/core-linux-x64-musl": "1.2.241",
+        "@swc/core-win32-arm64-msvc": "1.2.241",
+        "@swc/core-win32-ia32-msvc": "1.2.241",
+        "@swc/core-win32-x64-msvc": "1.2.241"
       }
     },
     "@swc/core-android-arm-eabi": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.239.tgz",
-      "integrity": "sha512-v316u9E517XQ48YwtkvfwN3nKw6oirJrBOmniA0IM5qhZYOIHDvm3YEhD+hmlEXWbRJ2iwK3ecN3J/HN725I8g==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.241.tgz",
+      "integrity": "sha512-VfbyFAQ+JT4kl4a7kPFM4pUSLHXnJ/bKIW0gAsVngBIcu73cz59HlylKiOtmx3UtXPsYu0Ort/qfC/UJfeEgrQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1497,9 +1497,9 @@
       }
     },
     "@swc/core-android-arm64": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.239.tgz",
-      "integrity": "sha512-HZRYhiRpTetnABVZIVEVnDDBSu+O/FP8sD1g+/dnYx8RZzbfbAsxvnauTRRuWDaqr3wcjDxGYCHiNf8Chaf2LQ==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.241.tgz",
+      "integrity": "sha512-WAJW542fxtO5iTP/vrBrf64dWfBq6rmWgL0HpM+ENFbqO4ME0xO49ky+5rMRAQdtwnJ5ZNkCvb49J+iIIY6yaw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1516,23 +1516,23 @@
       }
     },
     "@swc/core-darwin-arm64": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.239.tgz",
-      "integrity": "sha512-qucvHgJ5VQVZNdQacqbloWDYqZyD1pttBqyRWo3Wqr5mC+JAIJl+JsflFpV8QEgY52aMgk/cLVhTa46Si3L3Jw==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.241.tgz",
+      "integrity": "sha512-5lQaguosciAN6kOfmNY1UeitrwMyPUt4d/Z70A1ac5e1ZFuYlhOxGHuhkz6abEewLkS/b1CGruSAtphEEVGLmw==",
       "dev": true,
       "optional": true
     },
     "@swc/core-darwin-x64": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.239.tgz",
-      "integrity": "sha512-0iunP9diQpjtacY+YQDwWmUANe4nA54aPDcum4O2vnhFeAXWoYX0b7FmYdq7UqxpP5IxcBgQAl7QhEfDnGrvoA==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.241.tgz",
+      "integrity": "sha512-VtcCBdhOktYPDnEEL0f+pfGmvjIlmXWMZKIb48WTYunxwsehxQk79ZkLXc+TwZ3ur9GEoZHh31RaKqOj4QDHpQ==",
       "dev": true,
       "optional": true
     },
     "@swc/core-freebsd-x64": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.239.tgz",
-      "integrity": "sha512-CA5yf6hd6czwIHlp/89Y03B+19+3EWCAPESjAPmJFjiNv4aGtzkSH+cYljmKYSkkQlYXGdKAc3d5GwL0sUaQgQ==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.241.tgz",
+      "integrity": "sha512-i12GxWnm1LuvZ9T0HVB8+CFIhcFzTxu3u2U97LZNb7vbHGHehUwIb6GmTwUbF+wEdFkwsIKWTf3RpvnEejWUsA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1549,9 +1549,9 @@
       }
     },
     "@swc/core-linux-arm-gnueabihf": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.239.tgz",
-      "integrity": "sha512-/GsCHvbPcsFF6kYiWyDan8zq1t/Jc5/ksMTWuENmokMBGdTECffFZAtx44V25Iw6Ip6Oe5Uzo7Mdabh4U6sbmA==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.241.tgz",
+      "integrity": "sha512-lTSiPkfEscfYEZxsKLbVqISRvCcatB+h7eENy0+Qdqqyio0yTOMfG7837jZhfy1hCjAwT8x2sh77fbvfQD4dRA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1568,37 +1568,37 @@
       }
     },
     "@swc/core-linux-arm64-gnu": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.239.tgz",
-      "integrity": "sha512-VZ/oShno1H+ElO5FuhIacSvSgv5Ftzifkv1iAy9pi8e9cV6Y5RCxIEm6C28nCXNiyrSo5/AqqejGEZKt2pEblA==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.241.tgz",
+      "integrity": "sha512-H6lTvd6nm4eaOi4Ledo5z1a6LXzJ2WpHTRsf3FssM9qqwFmbvNIz9vCTI4jCR5Y3Ed3jlmQli+znzmWJ/qzLLQ==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-musl": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.239.tgz",
-      "integrity": "sha512-d24/2NEuvRAVFEFNRwwjlzuZhe442oUnhLuWRqh13bRBY7cRde3KIrxl4IMiVd5GvVKUy4JlhClmiV7Su9nVKw==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.241.tgz",
+      "integrity": "sha512-K8bXA+JtoD0g+w9wDyI3R0VkFaxFokF9KI0ioDVRfwDDNoFWq3slQWyN9fkj0dI9XagK15OcSuMGTH+h9B7veQ==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.239.tgz",
-      "integrity": "sha512-OKjj99kfCSrMEvWbWftSAgj29v5TxII+KCAuA284NoGYVcezzaO37C4TfrDjOW5/wtvDfWk97w8FfsOmrWKl0A==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.241.tgz",
+      "integrity": "sha512-jLr+mtNhHMcSRz0xZ9/R9g59kVmgekcz9RyXIFkO7RzJOGVzXxGxfO3pSsQ+u2tCpYbK9M6rMiaNoRYnQj3yNQ==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-musl": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.239.tgz",
-      "integrity": "sha512-BsX/ivpDmYFeqOHz5gA5OqtskO5mkEKyBRhhVnzc9AG9tbhz8X5zZMLPV398RCn48lmS/uS8MPXHkJKAlYA1BA==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.241.tgz",
+      "integrity": "sha512-yXkhlxTSH6ddcBCxwRHTnpj5TA0GXbWADjPIhhXG8KlM4KGjnEvfSBa1xtSNbJcYT8kBYM1n+jYf0dIX2je5eg==",
       "dev": true,
       "optional": true
     },
     "@swc/core-win32-arm64-msvc": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.239.tgz",
-      "integrity": "sha512-C5es8Aou6+PnZmk+h+Kay/UCctkwCPRonwRajLDa88x2elhmxE1pdLIPAJVp5RpOlFoPRbJAkc5I+4fV5njZ9g==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.241.tgz",
+      "integrity": "sha512-/f3ylWLHfUtRgHFER3FdH5QwDhO7siQ6h5ug0yVKXIDfNJhJVt9Hd+ZjMGJhNGTkzrl+uZmwXWBiklMcaMCtbQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1615,9 +1615,9 @@
       }
     },
     "@swc/core-win32-ia32-msvc": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.239.tgz",
-      "integrity": "sha512-24VMplxQTtOJk7cxpBViq9HozSc6Pg6MxBMuudTmGh6z3L//VxLn0wpUR9jLEvRUk/2i1p1DKpc6RQ0tYcNf9A==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.241.tgz",
+      "integrity": "sha512-HC1T9sWC9zuZ6C/WWTFMHdgKYv+qaOfWduIvNVqhECa+FXRcBTPtDgNBhMTc2lpt4biKf5iPHhAVZkP6Za3OOw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1634,9 +1634,9 @@
       }
     },
     "@swc/core-win32-x64-msvc": {
-      "version": "1.2.239",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.239.tgz",
-      "integrity": "sha512-qktIdFdGS6dpDnOGnImrOA9GpNMsVaGAycGcvoqoUYEkPf8dFCLKthEOzqA1fU01wKn3r1M5mi1eluM1ld5Hng==",
+      "version": "1.2.241",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.241.tgz",
+      "integrity": "sha512-BW1MHKdmi+DDBH+Z/XlhluIjZj9SMkMheeN95G71Z2Pim5LrvzIHf31UD0kYh6ZWWphP06Jlpzl0oi4stxeETw==",
       "dev": true,
       "optional": true
     },
@@ -1774,9 +1774,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
-      "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==",
+      "version": "18.7.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.9.tgz",
+      "integrity": "sha512-0N5Y1XAdcl865nDdjbO0m3T6FdmQ4ijE89/urOHLREyTXbpMWbSafx9y7XIsgWGtwUP2iYTinLyyW3FatAxBLQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -2363,9 +2363,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001378",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001378.tgz",
-      "integrity": "sha512-JVQnfoO7FK7WvU4ZkBRbPjaot4+YqxogSDosHv0Hv5mWpUESmN+UubMU6L/hGz8QlQ2aY5U0vR6MOs6j/CXpNA==",
+      "version": "1.0.30001381",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001381.tgz",
+      "integrity": "sha512-fEnkDOKpvp6qc+olg7+NzE1SqyfiyKf4uci7fAU38M3zxs0YOyKOxW/nMZ2l9sJbt7KZHcDIxUnbI0Iime7V4w==",
       "dev": true
     },
     "cardinal": {
@@ -2920,9 +2920,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.224",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.224.tgz",
-      "integrity": "sha512-dOujC5Yzj0nOVE23iD5HKqrRSDj2SD7RazpZS/b/WX85MtO6/LzKDF4TlYZTBteB+7fvSg5JpWh0sN7fImNF8w==",
+      "version": "1.4.225",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.225.tgz",
+      "integrity": "sha512-ICHvGaCIQR3P88uK8aRtx8gmejbVJyC6bB4LEC3anzBrIzdzC7aiZHY4iFfXhN4st6I7lMO0x4sgBHf/7kBvRw==",
       "dev": true
     },
     "emittery": {
@@ -5141,9 +5141,9 @@
       "dev": true
     },
     "marked": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
-      "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
+      "integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
       "dev": true
     },
     "marked-terminal": {


### PR DESCRIPTION
No point of forwarding the dependency updates to the alerts channel.