### PR TITLE
chore: automerge renovate patches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,7 +50,8 @@
     {
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "/^[~^]?0/",
-      "automerge": false,
+      "automerge": true,
+      "platformAutomerge": true,
       "dependencyDashboardApproval": false,
       "addLabels": ["dependencies", "major-upgrade"]
     }


### PR DESCRIPTION
@ZackKanter noticed that renovate is not automerging some of its PRs, e.g. this one https://github.com/Stedi/prettier-plugin-jsonata/pull/405