### PR TITLE
fix: add support for stages on SortNode

### DIFF
--- a/src/plugin/__tests__/index.unit.ts
+++ b/src/plugin/__tests__/index.unit.ts
@@ -70,6 +70,8 @@ describe("prettierPlugin", () => {
     ["**.foo"],
     ["foo ~> $max()"],
     ["foo^(<bar)"],
+    ["foo^(<bar)[0]"],
+    ["foo^(<bar)[bar = 1]"],
     ["loans@$foo#$bar"],
     ["loans@$foo"],
     ["loans#$bar"],

--- a/src/plugin/printer.ts
+++ b/src/plugin/printer.ts
@@ -347,7 +347,18 @@ const printSortNode: PrintNodeFunction<SortNode> = (node, path, options, printCh
   });
   const joinedSortTerms = join([",", line], sortTerms);
 
-  return group(["(", indent([softline, joinedSortTerms]), softline, ")"]);
+  return group([
+    "(",
+    indent([softline, joinedSortTerms]),
+    softline,
+    ")",
+    printNodeFocus(node),
+    printNodeIndex(node),
+    printStages(node, path, options, printChildren),
+    printPredicate(node, path, options, printChildren),
+    printNodeGroup(node, path, options, printChildren),
+    printKeepArray(node),
+  ]);
 };
 
 const printSortTermPrefix = (sortTerm: SortNode["terms"][0]) => {
@@ -509,7 +520,7 @@ const printPredicate: PrintNodeFunction = (node, path, options, printChildren) =
 };
 
 const printStages: PrintNodeFunction<
-  NameNode | VariableNode | ParentNode | BlockNode | FunctionNode | PartialFunctionNode
+  NameNode | VariableNode | ParentNode | BlockNode | FunctionNode | PartialFunctionNode | SortNode
 > = (node, path, options, printChildren) => {
   if (!node.stages) {
     return "";

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,7 @@ export interface SortNode extends Node {
       expression: JsonataASTNode;
     },
   ];
+  stages?: JsonataASTNode[];
 }
 
 export type UnaryNode = ObjectUnaryNode | ArrayUnaryNode | NegationUnaryNode;


### PR DESCRIPTION
Fixes https://github.com/Stedi/prettier-plugin-jsonata/issues/725

The filtering operator added after sorting is represented within the `stages` property of the "sort" node:

<img width="1174" alt="image" src="https://github.com/user-attachments/assets/faf82b4c-4744-4924-86bf-a28fbaaecd9e" />